### PR TITLE
[WIP] Install argocd and kuadrant in single cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin
+tmp
+kubeconfig

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,95 @@
+# Setting SHELL to bash allows bash commands to be executed by recipes.
+# Options are set to exit when a recipe line exits non-zero or a piped command fails.
+SHELL = /usr/bin/env bash -o pipefail
+.SHELLFLAGS = -ec
+
+MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
+PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
+
+OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
+ARCH := $(shell uname -m | tr '[:upper:]' '[:lower:]')
+# Container Engine to be used for building image and with kind
+CONTAINER_ENGINE ?= docker
+
+## Location to install dependencies to
+LOCALBIN ?= $(PROJECT_PATH)/bin
+$(LOCALBIN):
+	mkdir -p $(LOCALBIN)
+
+## Temp folder
+tmp:
+	umask 0000 && mkdir -p $@
+
+##@ Kind
+
+## Targets to use kind for deployment https://kind.sigs.k8s.io
+export KUBECONFIG = $(PWD)/kubeconfig
+
+KIND_CLUSTER_NAME ?= kuadrant-local
+KIND_K8S_VERSION ?= v1.31.0@sha256:53df588e04085fd41ae12de0c3fe4c72f7013bba32a20e7325357a1ac94ba865
+.PHONY: kind-create-cluster
+kind-create-cluster-%: kind start-cloud-provider-kind ## Create the "kuadrant-local" kind cluster.
+	KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) create cluster --wait 5m \
+		--image kindest/node:$(KIND_K8S_VERSION) \
+		--name $(KIND_CLUSTER_NAME)-$* \
+		--config util/kind-cluster.yaml
+
+.PHONY: kind-delete-cluster
+kind-delete-cluster-%: kind stop-cloud-provider-kind ## Delete the "kuadrant-local" kind cluster.
+	- KIND_EXPERIMENTAL_PROVIDER=$(CONTAINER_ENGINE) $(KIND) delete cluster --name $(KIND_CLUSTER_NAME)-$*
+
+kind-apply-argocd: kustomize
+	$(KUSTOMIZE) build manifests/argocd-install | yq 'select(.kind == "CustomResourceDefinition")' | kubectl apply -f -
+	sleep 2
+	kubectl wait --for condition=established --timeout=60s crd --all
+	$(KUSTOMIZE) build manifests/argocd-install | yq 'select(.kind != "CustomResourceDefinition")' | kubectl apply -f -
+
+##@ Kind cloud provider
+CPK_PID_FILE = tmp/cloud-provider-kind.pid
+
+start-cloud-provider-kind: tmp
+	hack/run-background-process.sh $(KIND_CLOUD_PROVIDER) $(CPK_PID_FILE) tmp/cloud-provider-kind.log
+stop-cloud-provider-kind:
+	- kill -TERM $(shell cat $(CPK_PID_FILE)) && rm $(CPK_PID_FILE)
+
+##@ ArgoCD management targets
+ARGOCD_PASSWD = $(shell kubectl -n argocd get secret argocd-initial-admin-secret -o jsonpath="{.data.password}" | base64 -d)
+ARGOCD_IP = $(shell kubectl -n argocd get svc argocd-server -o jsonpath="{.status.loadBalancer.ingress[0].ip}")
+argocd-url:
+	@echo -e "\tURL: \thttps://$(ARGOCD_IP)"
+	@echo -e "\tuser: \tadmin"
+	@echo -e "\tpass: \t$(ARGOCD_PASSWD)"
+
+
+##@ Tooling
+
+KUSTOMIZE = $(PROJECT_PATH)/bin/kustomize
+KUSTOMIZE_VERSION = v5@v5.5.0
+.PHONY: kustomize
+kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
+$(KUSTOMIZE):
+	 test -s $(KUSTOMIZE) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/$(KUSTOMIZE_VERSION)
+
+
+KIND = $(PROJECT_PATH)/bin/kind
+KIND_VERSION ?= v0.24.0
+.PHONY: kind
+kind: $(KIND) ## Download kind locally if necessary
+$(KIND): $(LOCALBIN)
+	test -s $(KIND) || GOBIN=$(LOCALBIN) go install sigs.k8s.io/kind@$(KIND_VERSION)
+
+KIND_CLOUD_PROVIDER = $(PROJECT_PATH)/bin/cloud-provider-kind
+KIND_CLOUD_PROVIDER_VERSION ?= latest
+.PHONY: kind-cloud-provider
+kind-cloud-provider: $(KIND_CLOUD_PROVIDER) ## Download kind locally if necessary
+$(KIND_CLOUD_PROVIDER): $(LOCALBIN)
+	test -s $(KIND_CLOUD_PROVIDER) ||GOBIN=$(LOCALBIN) go install sigs.k8s.io/cloud-provider-kind@$(KIND_CLOUD_PROVIDER_VERSION)
+
+##@ Install argocd
+ARGOCD ?= $(LOCALBIN)/argocd
+ARGOCD_VERSION ?= v2.4.12
+ARGOCD_DOWNLOAD_URL ?= https://github.com/argoproj/argo-cd/releases/download/v2.4.13/argocd-$(OS)-$(ARCH)
+argocd: $(ARGOCD) ## Download argocd CLI locally if necessary
+$(ARGOCD):
+	curl -sL $(ARGOCD_DOWNLOAD_URL) -o $(ARGOCD)
+	chmod +x $(ARGOCD)

--- a/hack/run-background-process.sh
+++ b/hack/run-background-process.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+BINARY=$1
+PID_FILE=$2
+LOG_FILE=$3
+
+set -e
+
+if [[ -f ${PID_FILE} ]]; then
+    PID=$(cat ${PID_FILE})
+    if [[ $(ps -p ${PID} -o command --no-headers) != "" ]]; then
+        echo "${BINARY} already running"
+        exit 0
+    fi
+fi
+
+# start the process
+nohup ${BINARY} > ${LOG_FILE} 2>&1 &
+echo $! > ${PID_FILE}

--- a/manifests/argocd-applications/argocd-install-application.yaml
+++ b/manifests/argocd-applications/argocd-install-application.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd-install
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    name: in-cluster
+  project: default
+  source:
+    path: manifests/argocd-install
+    # repoURL: https://github.com/kuadrant/deployment
+    # targetRevision: HEAD
+    repoURL: https://github.com/roivaz/kuadrant-deployment
+    targetRevision: argocd-setup
+  syncPolicy:
+    automated:
+      selfHeal: true

--- a/manifests/argocd-applications/kuadrant-applicationset.yaml
+++ b/manifests/argocd-applications/kuadrant-applicationset.yaml
@@ -1,0 +1,36 @@
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kuadrant-install
+  namespace: argocd
+spec:
+  ignoreApplicationDifferences:
+    - jsonPointers:
+        - /spec/syncPolicy
+        - /spec/source/targetRevision
+  goTemplate: true
+  generators:
+    - git:
+        # repoURL: https://github.com/kuadrant/deployment
+        # revision: HEAD
+        repoURL: https://github.com/roivaz/kuadrant-deployment
+        revision: argocd-setup
+        files:
+          - path: manifests/kuadrant/**/argocd-config.yaml
+  template:
+    metadata:
+      name: "{{.path.basename}}"
+    spec:
+      project: default
+      source:
+        # repoURL: https://github.com/kuadrant/deployment
+        # targetRevision: main
+        repoURL: https://github.com/roivaz/kuadrant-deployment
+        targetRevision: argocd-setup
+        path: "{{.path.path}}"
+      destination:
+        name: in-cluster
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true

--- a/manifests/argocd-applications/kustomization.yaml
+++ b/manifests/argocd-applications/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+resources:
+  - argocd-install-application.yaml
+  - operator-lifecycle-manager-application.yaml
+  - kuadrant-applicationset.yaml

--- a/manifests/argocd-applications/operator-lifecycle-manager-application.yaml
+++ b/manifests/argocd-applications/operator-lifecycle-manager-application.yaml
@@ -1,0 +1,21 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: operator-lifecycle-manager
+  namespace: argocd
+spec:
+  destination:
+    namespace: olm
+    name: in-cluster
+  project: default
+  source:
+    path: manifests/operator-lifecycle-manager
+    # repoURL: https://github.com/kuadrant/deployment
+    # targetRevision: HEAD
+    repoURL: https://github.com/roivaz/kuadrant-deployment
+    targetRevision: argocd-setup
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - ServerSideApply=true

--- a/manifests/argocd-install/app-of-apps-application.yaml
+++ b/manifests/argocd-install/app-of-apps-application.yaml
@@ -1,0 +1,22 @@
+# App of Apps keeps ArgoCD Applications in sync
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: app-of-apps
+  namespace: argocd
+spec:
+  destination:
+    namespace: argocd
+    name: in-cluster
+  project: default
+  source:
+    path: manifests/argocd-applications
+    # repoURL: https://github.com/kuadrant/deployment
+    # targetRevision: HEAD
+    repoURL: https://github.com/roivaz/kuadrant-deployment
+    targetRevision: argocd-setup
+  syncPolicy:
+    automated:
+      selfHeal: true
+
+

--- a/manifests/argocd-install/kustomization.yaml
+++ b/manifests/argocd-install/kustomization.yaml
@@ -1,0 +1,15 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: argocd
+resources:
+  - namespace.yaml
+  - https://raw.githubusercontent.com/argoproj/argo-cd/refs/tags/v2.12.6/manifests/install.yaml
+  - app-of-apps-application.yaml
+patches:
+  - target:
+      kind: Service
+      name: argocd-server
+    patch: |-
+      - op: add
+        path: /spec/type
+        value: LoadBalancer

--- a/manifests/argocd-install/namespace.yaml
+++ b/manifests/argocd-install/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: argocd

--- a/manifests/kuadrant/gateway-api/argocd-config.yaml
+++ b/manifests/kuadrant/gateway-api/argocd-config.yaml
@@ -1,0 +1,1 @@
+# Use this file to configure some parameters of the generated Application

--- a/manifests/kuadrant/gateway-api/kustomization.yaml
+++ b/manifests/kuadrant/gateway-api/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.1.0/standard-install.yaml

--- a/manifests/kuadrant/istio/argocd-config.yaml
+++ b/manifests/kuadrant/istio/argocd-config.yaml
@@ -1,0 +1,1 @@
+# Use this file to configure some parameters of the generated Application

--- a/manifests/kuadrant/istio/istio.yaml
+++ b/manifests/kuadrant/istio/istio.yaml
@@ -1,0 +1,28 @@
+apiVersion: sailoperator.io/v1alpha1
+kind: Istio
+metadata:
+  name: default
+  namespace: istio-system
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  version: v1.23.0
+  namespace: istio-system
+  # Disable autoscaling to reduce dev resources
+  values:
+    pilot:
+      autoscaleEnabled: false
+
+---
+# Configure envoy access logging.
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mesh-default
+  namespace: istio-system
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec:
+  accessLogging:
+    - providers:
+        - name: envoy

--- a/manifests/kuadrant/istio/kustomization.yaml
+++ b/manifests/kuadrant/istio/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - operator.yaml
+  - istio.yaml
+  - monitoring.yaml

--- a/manifests/kuadrant/istio/monitoring.yaml
+++ b/manifests/kuadrant/istio/monitoring.yaml
@@ -1,0 +1,15 @@
+# TODO: no monitoring stack configured yet
+# apiVersion: monitoring.coreos.com/v1
+# kind: ServiceMonitor
+# metadata:
+#   name: istiod-monitor
+#   namespace: istio-system
+# spec:
+#   targetLabels:
+#     - app
+#   selector:
+#     matchLabels:
+#       istio: pilot
+#   endpoints:
+#     - port: http-monitoring
+#       interval: 30s

--- a/manifests/kuadrant/istio/namespace.yaml
+++ b/manifests/kuadrant/istio/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: istio-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"

--- a/manifests/kuadrant/istio/operator.yaml
+++ b/manifests/kuadrant/istio/operator.yaml
@@ -1,0 +1,23 @@
+kind: OperatorGroup
+apiVersion: operators.coreos.com/v1
+metadata:
+  name: sail
+  namespace: istio-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec: {}
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sailoperator
+  namespace: istio-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  channel: candidates
+  installPlanApproval: Automatic
+  name: sailoperator
+  source: operatorhubio-catalog
+  sourceNamespace: olm

--- a/manifests/kuadrant/kuadrant-operator/argocd-config.yaml
+++ b/manifests/kuadrant/kuadrant-operator/argocd-config.yaml
@@ -1,0 +1,1 @@
+# Use this file to configure some parameters of the generated Application

--- a/manifests/kuadrant/kuadrant-operator/kuadrant.yaml
+++ b/manifests/kuadrant/kuadrant-operator/kuadrant.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuadrant.io/v1beta1
+kind: Kuadrant
+metadata:
+  name: kuadrant
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+spec: {}

--- a/manifests/kuadrant/kuadrant-operator/kustomization.yaml
+++ b/manifests/kuadrant/kuadrant-operator/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: kuadrant-system
+resources:
+  - namespace.yaml
+  - operator.yaml
+  - redis.yaml
+  - kuadrant.yaml

--- a/manifests/kuadrant/kuadrant-operator/namespace.yaml
+++ b/manifests/kuadrant/kuadrant-operator/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kuadrant-system
+  annotations:
+    argocd.argoproj.io/sync-wave: "-2"

--- a/manifests/kuadrant/kuadrant-operator/operator.yaml
+++ b/manifests/kuadrant/kuadrant-operator/operator.yaml
@@ -1,0 +1,38 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: kuadrant-operator-catalog
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  sourceType: grpc
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v0.11.0
+  displayName: Kuadrant Operators
+  publisher: grpc
+  updateStrategy:
+    registryPoll:
+      interval: 30m
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: kuadrant-operator
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: kuadrant-operator
+  source: operatorhubio-catalog
+  sourceNamespace: olm
+
+---
+kind: OperatorGroup
+apiVersion: operators.coreos.com/v1
+metadata:
+  name: kuadrant
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"
+spec:
+  upgradeStrategy: Default

--- a/manifests/kuadrant/kuadrant-operator/redis.yaml
+++ b/manifests/kuadrant/kuadrant-operator/redis.yaml
@@ -1,0 +1,75 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: limitador-redis
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: limitador-redis
+  replicas: 1
+  serviceName: limitador-redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: limitador-redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:6.0.5-alpine
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: redis
+              containerPort: 6379
+          livenessProbe:
+            initialDelaySeconds: 5
+            tcpSocket:
+              port: 6379
+          readinessProbe:
+            initialDelaySeconds: 15
+            tcpSocket:
+              port: 6379
+          resources:
+            requests:
+              cpu: 5m
+              memory: 32Mi
+            limits:
+              cpu: 50m
+              memory: 64Mi
+          ## container > limitador-redis > volumeMounts
+          volumeMounts:
+            - name: limitador-redis-storage
+              mountPath: /data
+              subPath: data
+  volumeClaimTemplates:
+    - metadata:
+        name: limitador-redis-storage
+      spec:
+        volumeMode: Filesystem
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: 20Gi
+
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: limitador-redis
+spec:
+  ports:
+    - name: redis
+      port: 6379
+      protocol: TCP
+      targetPort: redis
+  selector:
+    app.kubernetes.io/name: limitador-redis
+  type: ClusterIP
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: redis-config
+stringData:
+  URL: redis://limitador-redis:6379

--- a/manifests/operator-lifecycle-manager/kustomization.yaml
+++ b/manifests/operator-lifecycle-manager/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.28.0/crds.yaml
+  - https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.28.0/olm.yaml
+patches:
+  - target:
+      kind: CustomResourceDefinition
+    patch: |-
+      - op: add
+        path: /metadata/annotations/argocd.argoproj.io~1sync-wave
+        value: "-1"

--- a/util/kind-cluster.yaml
+++ b/util/kind-cluster.yaml
@@ -1,0 +1,7 @@
+---
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+- role: worker
+- role: worker


### PR DESCRIPTION
This PR adds the minimal setup to have a Kuadrant installation managed by argocd in a local kind cluster. ArgoCD manages itself using the app-of-apps pattern and all the Kuadrant related Applications are managed by an ApplicationSet that automatically generates them based on the paths that exist in the GitHub repo under `manifests/kuadrant`.

There is an outstanding issue with the installation of Istio using sail-operator, which the kuadrant-operator is not detecting. It seems to be somehow with this work https://github.com/Kuadrant/kuadrant-operator/pull/944#discussion_r1804747498, where similar issues were detected, but right now this installation method is not working properly. I really wanted to use sail here as it is the only install method for Istio that provides upgrade funtionality using GitOps, but we might need to switch to a different one while the issue is not addressed, wdyt @maleck13 ?

## Steps to bring up the environment

Issue the following commands in order

`make kind-create-cluster-1`
`make kind-apply-argocd`

Open argocd UI in a browser using the url, user and pass shown by the follwing  command:

`make argocd-url`
