### PR TITLE
Make it work for openshift-gitops

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ To install in a remote cluster, it is assumed that an argocd instance is already
     * deployment.kuadrant.io/hub=true: marks this cluster as the hub. Certain resources will only be installed in the hub cluster.
     * vendor=OpenShift: marks this cluster as an OpenShift cluster. A k8s cluster is assumed if this label is not present.
 
-2. `kubectl create ns argocd && kubectl apply -f manifests/argocd-install/app-of-apps-application.yaml`
+2. Apply the `app-of-apps-application.yaml` manifest to the namespace where the argocd instance is running. Note that you will need the `yq` tool for the following command to work. You can install the tool using `make yq`, otherwise you can manually edit the yaml file.
 
-3. Coffee time. It should all be green afte some minutes.
+```
+> export ARGOCD_NAMESPACE="namespace-here"
+> yq e ".spec.destination.namespace = \"$ARGOCD_NAMESPACE\"" manifests/argocd-install/app-of-apps-application.yaml | kubectl -n $ARGOCD_NAMESPACE apply -f -
+```
+
+6. Coffee time. It should all be green afte some minutes.

--- a/examples/openshift-gitops/README.md
+++ b/examples/openshift-gitops/README.md
@@ -1,0 +1,7 @@
+After openshift-gitops  is installed in the cluster, resolution of helm charts by kustomize needs to be enabled by issuing the following command:
+
+```
+kubectl patch argocd openshift-gitops --type=json -p='[{"op":"add","path":"/spec/kustomizeBuildOptions","value":"--enable-helm"}]'
+```
+
+If you experience errors in argocd about the flag '--enable-helm' not being set, delete the `openshift-gitops-application-controller-*` pods in the `openshift-gitops` namespace to force a refresh.

--- a/examples/openshift-gitops/rbac.yaml
+++ b/examples/openshift-gitops/rbac.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: argocd-application-controller-cluster-admin
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: openshift-gitops-argocd-application-controller
+    namespace: openshift-gitops

--- a/examples/openshift-gitops/subscription.yaml
+++ b/examples/openshift-gitops/subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-gitops-operator
+spec:
+  channel: latest
+  installPlanApproval: Automatic
+  name: openshift-gitops-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
The default openshift-gitops argocd instance has some level of cluster scoped permissions, but not enough to install gateway-api, istio and kuadrant. See https://docs.openshift.com/gitops/1.14/declarative_clusterconfig/customizing-permissions-by-creating-user-defined-cluster-roles-for-cluster-scoped-instances.html further reading on this subject.

This PR adds an example subscription and a clusterrolebinding to install openshit-gitops and grant its default argocd instance the cluster-admin clusterrole, which allows it to properly install all the required resources.

I also modified slightly the readme to accomodate to argocd installations that don't use the `argocd` namespace.