### PR TITLE
Fix/Add small fixes to Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ kind-create-cluster-%: kind kustomize ## Create the "kuadrant-local" kind cluste
 	$(MAKE) kind-install-metallb-$*
 
 kind-install-metallb-%: export PODMAN_IGNORE_CGROUPSV1_WARNING="1"
-kind-isntall-metallb-%: export KUBECONFIG = $(PWD)/kubeconfig
+kind-install-metallb-%: export KUBECONFIG = $(PWD)/kubeconfig
 kind-install-metallb-%: yq
 	kubectl config use-context kind-kuadrant-local-$*
 	$(KUSTOMIZE) build https://github.com/metallb/metallb/config/native/?ref=v0.14.8 | kubectl apply -f -
@@ -67,10 +67,10 @@ kind-delete-cluster-%: kind ## Delete the "kuadrant-local" kind cluster.
 
 kind-apply-argocd: export KUBECONFIG = $(PWD)/kubeconfig
 kind-apply-argocd: kustomize
-	$(KUSTOMIZE) build manifests/argocd-install | yq 'select(.kind == "CustomResourceDefinition")' | kubectl apply -f -
+	$(KUSTOMIZE) build manifests/argocd-install | $(YQ) 'select(.kind == "CustomResourceDefinition")' | kubectl apply -f -
 	sleep 2
 	kubectl wait --for condition=established --timeout=60s crd --all
-	$(KUSTOMIZE) build manifests/argocd-install | yq 'select(.kind != "CustomResourceDefinition")' | kubectl apply -f -
+	$(KUSTOMIZE) build manifests/argocd-install | $(YQ) 'select(.kind != "CustomResourceDefinition")' | kubectl apply -f -
 
 kind-skupper-init-%: export KUBECONFIG = $(PWD)/kubeconfig
 kind-skupper-init-%: skupper

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # deployment
-This repo contains some example deployments for Kuadrant. 
+This repo contains some example deployments for Kuadrant.
 
-- All deployments use kustomize and regular kuberentes resources
+- All deployments use kustomize and regular kubernetes resources
 - We will provide basic instructions for installing and configuring ArgoCD but more advanced topics should be found via argocd docs
 
 ## Phases
@@ -19,11 +19,11 @@ This repo contains some example deployments for Kuadrant.
 
 - Extend on phase 1 to include a second cluster
 - Introduce an external redis configuration
-- Introduce and install thanos 
+- Introduce and install thanos
 
 ## Instructions
 
-The following instructions assume you have cloned the repo locally adn are in the project's root directory.
+The following instructions assume you have cloned the repo locally and are in the project's root directory.
 
 ### Local
 
@@ -45,7 +45,7 @@ To install in a remote cluster, it is assumed that an argocd instance is already
 make deploy ARGOCD_NAMESPACE="<argocd-installation-namespace>"
 ```
 
-1. Coffee time. It should all be green afte some minutes.
+1. Coffee time. It should all be green after some minutes.
 
 
 ## Development
@@ -56,7 +56,7 @@ Fork the repo and create a branch. Then, deploy setting your repoURL and targetR
 
 ```
 make local-setup REPO_URL=<forked-repository-url> TARGET_REVISION=<branch|tag|commit>
-``` 
+```
 
 * For a remote setup you need to also add the namespace where argocd is installed. Make sure to load the appropriate kubeconfig context.
 

--- a/README.md
+++ b/README.md
@@ -29,6 +29,15 @@ The following instructions assume you have cloned the repo locally and are in th
 
 To deploy the setup in local kind clusters just issue a `make local-setup` command in a shell. Information on how to connect to the argocd UI will be printed in the output.
 
+TIP: If using Linux, possibly `make local-setup` target fails with no clear information about the reason of the failure (you will need to increase kind log verbosity level starting with `-v 4`). It will possibly be caused by running out of inotify resources and inotify file watches. In order to increase them add the following 2 lines to `/etc/sysctl.conf`:
+
+```
+fs.inotify.max_user_instances=8192
+fs.inotify.max_user_watches=524288
+```
+
+And execute `sudo sysctl -p` so the new inotify configuration is loaded.
+
 ### Remote
 
 To install in a remote cluster, it is assumed that an argocd instance is already up and running in the cluster. An example is available on how to install an argocd instance in OpenShift using the argocd-operator.


### PR DESCRIPTION
I've was trying to use the `local-setup` and initially it didn't work because of:
- Second cluster failing to create on `Starting control-plane` phase: no direct error was reported, but the reason was running out of inotify resources (the same happened to @roivaz , which also uses Linux). I added a tip to README on what to do to fix it
- `bin/yq: No such file or directory` caused because on 2 places it was using `yq` instead of `bin/yq`
- Also, I fixed other minor typos on both README and Makefile