### PR TITLE
Add a gateway

### DIFF
--- a/examples/openshift-gitops/README.md
+++ b/examples/openshift-gitops/README.md
@@ -1,7 +1,7 @@
 After openshift-gitops  is installed in the cluster, resolution of helm charts by kustomize needs to be enabled by issuing the following command:
 
 ```
-kubectl patch argocd openshift-gitops --type=json -p='[{"op":"add","path":"/spec/kustomizeBuildOptions","value":"--enable-helm"}]'
+kubectl -n openshift-gitops patch argocd openshift-gitops --type=json -p='[{"op":"add","path":"/spec/kustomizeBuildOptions","value":"--enable-helm"}]'
 ```
 
 If you experience errors in argocd about the flag '--enable-helm' not being set, delete the `openshift-gitops-application-controller-*` pods in the `openshift-gitops` namespace to force a refresh.

--- a/manifests/kuadrant/cert-manager/argocd-config.yaml
+++ b/manifests/kuadrant/cert-manager/argocd-config.yaml
@@ -1,0 +1,1 @@
+# Use this file to configure some parameters of the generated Application

--- a/manifests/kuadrant/cert-manager/base/kustomization.yaml
+++ b/manifests/kuadrant/cert-manager/base/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/manifests/kuadrant/cert-manager/base/namespace.yaml
+++ b/manifests/kuadrant/cert-manager/base/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  annotations:
+    argocd.argoproj.io/sync-wave: "-1"

--- a/manifests/kuadrant/cert-manager/overlays/k8s/kustomization.yaml
+++ b/manifests/kuadrant/cert-manager/overlays/k8s/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cert-manager
+resources:
+  - ../../base
+  - operator.yaml

--- a/manifests/kuadrant/cert-manager/overlays/k8s/operator.yaml
+++ b/manifests/kuadrant/cert-manager/overlays/k8s/operator.yaml
@@ -1,0 +1,20 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: cert-manager
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: cert-manager
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cert-manager
+  source: operatorhubio-catalog
+  sourceNamespace: olm

--- a/manifests/kuadrant/cert-manager/overlays/openshift/cert-manager.yaml
+++ b/manifests/kuadrant/cert-manager/overlays/openshift/cert-manager.yaml
@@ -1,0 +1,11 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+    argocd.argoproj.io/sync-wave: "1"
+  name: cluster
+spec:
+  logLevel: Normal
+  managementState: Managed
+  operatorLogLevel: Normal

--- a/manifests/kuadrant/cert-manager/overlays/openshift/kustomization.yaml
+++ b/manifests/kuadrant/cert-manager/overlays/openshift/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: cert-manager
+resources:
+  - ../../base
+  - operator.yaml
+  - cert-manager.yaml

--- a/manifests/kuadrant/cert-manager/overlays/openshift/operator.yaml
+++ b/manifests/kuadrant/cert-manager/overlays/openshift/operator.yaml
@@ -1,0 +1,23 @@
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: cert-manager-operator
+spec:
+  targetNamespaces:
+    - cert-manager-operator
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  annotations:
+    argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+  name: openshift-cert-manager-operator
+spec:
+  channel: stable-v1
+  installPlanApproval: Automatic
+  name: openshift-cert-manager-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace

--- a/manifests/kuadrant/gateway/argocd-config.yaml
+++ b/manifests/kuadrant/gateway/argocd-config.yaml
@@ -1,0 +1,1 @@
+# Use this file to configure some parameters of the generated Application

--- a/manifests/kuadrant/gateway/base/gateway.yaml
+++ b/manifests/kuadrant/gateway/base/gateway.yaml
@@ -9,11 +9,11 @@ kind: Gateway
 metadata:
   name: public
   annotations:
-    # You can add here annotations to configure how the Service that exposes the gateway.
+    # You can add here annotations to configure how the Service exposes the Gateway pods.
     # This is useful to configure how the cloud provider exposes the Gateway to the internet.
     # See the cloud provider's documentation to discover available options.
     #
-    # Example: this annotations configures the AWS cloud load balancer to enable proxy-protocol (highly recommentded
+    # Example: this annotation configures the AWS cloud load balancer to enable proxy-protocol (highly recommentded
     # for source IP detection)
     service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
 
@@ -53,7 +53,7 @@ spec:
 # service account for istio Gateway, otherwise it is deleted by argocd
 # because istio propagates all labels and annotations from the Gatewawy to the
 # ServiceAccount, which includes the argocd "app.kubernetes.io/instance=xxxx" label.
-# If the resource is not added explicitely to the Application, agocd deletes it due to this label.
+# If the resource is not added explicitly to the Application, agocd deletes it due to this label.
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/manifests/kuadrant/gateway/base/gateway.yaml
+++ b/manifests/kuadrant/gateway/base/gateway.yaml
@@ -1,0 +1,144 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: public
+
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: public
+  annotations:
+    # You can add here annotations to configure how the Service that exposes the gateway.
+    # This is useful to configure how the cloud provider exposes the Gateway to the internet.
+    # See the cloud provider's documentation to discover available options.
+    #
+    # Example: this annotations configures the AWS cloud load balancer to enable proxy-protocol (highly recommentded
+    # for source IP detection)
+    service.beta.kubernetes.io/aws-load-balancer-proxy-protocol: "*"
+
+    # You can apply Istio Mesh configuration options on a per Gateway basis using the "proxy.istio.io/config"
+    # annotation. See https://istio.io/latest/docs/reference/config/istio.mesh.v1alpha1/#ProxyConfig for available options.
+    #
+    # Example: this will enable proxy protocol in the gateway listeners as well as configure the gateway as the internet
+    # facing one (first trusted proxy in the request path), which is important for source IP detection
+    # (https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_conn_man/headers#config-http-conn-man-headers-x-forwarded-for).
+    proxy.istio.io/config: '{"gatewayTopology":{"numTrustedProxies":0,"proxyProtocol":{}}}'
+spec:
+  gatewayClassName: istio
+  listeners:
+    # HTTP
+    - name: http
+      port: 80
+      protocol: HTTP
+      allowedRoutes:
+        namespaces:
+          from: All
+    # HTTPS
+    - name: https
+      hostname: "your.hostname.here"
+      port: 443
+      protocol: HTTPS
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - group: ""
+            name: certificate
+            kind: Secret
+      allowedRoutes:
+        namespaces:
+          from: All
+
+---
+# service account for istio Gateway, otherwise it is deleted by argocd
+# because istio propagates all labels and annotations from the Gatewawy to the
+# ServiceAccount, which includes the argocd "app.kubernetes.io/instance=xxxx" label.
+# If the resource is not added explicitely to the Application, agocd deletes it due to this label.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: public-istio
+
+---
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: public
+spec:
+  # Match the generated Deployment by reference
+  # Note: Do not use `kind: Gateway`.
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: public-istio
+  minReplicas: 2
+  maxReplicas: 4
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70
+
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: public
+spec:
+  maxUnavailable: 25%
+  selector:
+    # Match the generated Deployment by label
+    matchLabels:
+      gateway.networking.k8s.io/gateway-name: public
+
+---
+# [NOTE] This is a partial Deployment resource. The expected behavior is that
+# argocd patches the kuadrant-operator owned Deployment instance, adding these fields
+# but without touching naything else.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: public-istio
+spec:
+  template:
+    spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              gateway.networking.k8s.io/gateway-name: public
+        - maxSkew: 1
+          topologyKey: kubernetes.io/zone
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              gateway.networking.k8s.io/gateway-name: public
+
+---
+######################
+#### HTTP -> HTTPS ###
+######################
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: http-filter-redirect
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      sectionName: http
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: public
+      sectionName: http-pub
+  rules:
+    - filters:
+        - type: RequestRedirect
+          requestRedirect:
+            scheme: https
+            statusCode: 301

--- a/manifests/kuadrant/gateway/base/kustomization.yaml
+++ b/manifests/kuadrant/gateway/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+namespace: public
+resources:
+  - gateway.yaml

--- a/manifests/kuadrant/gateway/overlays/k8s/kustomization.yaml
+++ b/manifests/kuadrant/gateway/overlays/k8s/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/manifests/kuadrant/gateway/overlays/openshift/kustomization.yaml
+++ b/manifests/kuadrant/gateway/overlays/openshift/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base

--- a/manifests/kuadrant/istio/base/istio.yaml
+++ b/manifests/kuadrant/istio/base/istio.yaml
@@ -33,6 +33,20 @@ spec:
           labelSelector:
             matchLabels:
               app: istiod
+    meshConfig:
+      defaultConfig:
+        # disable server headers in envoy proxies
+        proxyHeaders:
+          forwardedClientCert: SANITIZE
+          server:
+            disabled: true
+          attemptCount:
+            disabled: true
+          envoyDebugHeaders:
+            disabled: true
+          metadataExchangeHeaders:
+            mode: IN_MESH
+
 ---
 # Configure envoy access logging.
 apiVersion: telemetry.istio.io/v1alpha1

--- a/manifests/kuadrant/kuadrant-operator/base/operator.yaml
+++ b/manifests/kuadrant/kuadrant-operator/base/operator.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.0.0
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.0.2
   displayName: Kuadrant Operators
   publisher: grpc
   updateStrategy:

--- a/manifests/kuadrant/kuadrant-operator/base/operator.yaml
+++ b/manifests/kuadrant/kuadrant-operator/base/operator.yaml
@@ -6,7 +6,7 @@ metadata:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.0.0-rc4
+  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.0.0
   displayName: Kuadrant Operators
   publisher: grpc
   updateStrategy:
@@ -21,7 +21,7 @@ metadata:
   annotations:
     argocd.argoproj.io/sync-wave: "-1"
 spec:
-  channel: preview
+  channel: stable
   installPlanApproval: Automatic
   name: kuadrant-operator
   source: kuadrant-operator-catalog


### PR DESCRIPTION
This PR adds the following:

* Deploy a gateway with production ready configurations: 
   * HPA, PDB, topologySpreadConstraints, etc.
   * Disabled server headers
   * Example configuration of proxy-protocol in the Gateway
* Deploy cert-manager, which was missing
* Upgrade kuadrant to v1.0.0

This can be tested locally using

```
make local-setup REPO_URL=https://github.com/roivaz/kuadrant-deployment TARGET_REVISION=add-a-gateway
```