### PR TITLE
Fix missing apiVersion in ConfigMap

### DIFF
--- a/manifests/observability-worker/overlays/openshift/cluster-monitoring-config.yaml
+++ b/manifests/observability-worker/overlays/openshift/cluster-monitoring-config.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cluster-monitoring-config


### PR DESCRIPTION
Fixes a missing apiVersion in a resource.

@slopezz we included the `cluster-monitoring-config` ConfigMap at the last minute after I tested manually that it worked properly. Coming back to the argocd Application after merging, I saw the problem.